### PR TITLE
fix: unify project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Particle Accelerator
+# Particle Project
 
 # Particle Project
 
@@ -39,7 +39,7 @@ For any questions or suggestions, please open an issue or contact the maintainer
 
 ## More Detailed Overview
 
-The Particle Accelerator project is an interactive particle simulation tool that allows users to adjust various parameters to see how they affect the behavior of particles on a canvas. The application provides a user-friendly interface for customizing the simulation and saving/loading these configurations.
+The Particle Project project is an interactive particle simulation tool that allows users to adjust various parameters to see how they affect the behavior of particles on a canvas. The application provides a user-friendly interface for customizing the simulation and saving/loading these configurations.
 
 ## Detailed Features List
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <!-- Begin Section 1: Meta and Title -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Particle Accelerator</title>
+  <title>Particle Project</title>
   <!-- End Section 1 -->
 
   <!-- Begin Section 2: Stylesheet -->


### PR DESCRIPTION
## Summary
- rename Particle Accelerator to Particle Project in the app title
- replace all "Particle Accelerator" references in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685422e4c6288320903339bfff886580