### PR TITLE
Add PUT endpoint test

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
 const app = require('../server');
 
 function startServer() {
@@ -26,5 +28,26 @@ test('GET /user_preferences.json returns particleCount', async () => {
   assert.strictEqual(res.status, 200);
   const json = await res.json();
   assert.ok('particleCount' in json);
+  server.close();
+});
+
+test('PUT /user_preferences.json saves preferences', async () => {
+  const server = await startServer();
+  const port = server.address().port;
+  const prefsPath = path.join(__dirname, '..', 'user_preferences.json');
+  const original = fs.readFileSync(prefsPath, 'utf8');
+  const newPrefs = { particleCount: 200 };
+
+  const res = await fetch(`http://localhost:${port}/user_preferences.json`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(newPrefs)
+  });
+
+  assert.strictEqual(res.status, 200);
+  const saved = JSON.parse(fs.readFileSync(prefsPath, 'utf8'));
+  assert.deepStrictEqual(saved, newPrefs);
+
+  fs.writeFileSync(prefsPath, original);
   server.close();
 });


### PR DESCRIPTION
## Summary
- add fs and path modules in test file
- write test for updating preferences via PUT endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685422e86d0c83209cf9655c74a99007