### PR TITLE
Fix PORT env var usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
    npm start
    ```
 
-   The app should now be running on `http://localhost:3000`.
+   The app should now be running on `http://localhost:3000` by default. You can
+   set a different port by defining the `PORT` environment variable before
+   running the command.
 
 ## Description
 

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 // Middleware to serve static files
 app.use(express.static(path.join(__dirname)));


### PR DESCRIPTION
## Summary
- allow custom PORT in server
- document `PORT` usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685422e5fb7c8320b23c2f19fe3030d4